### PR TITLE
Fix build issues related to missing <string> header

### DIFF
--- a/src/fs/file.h
+++ b/src/fs/file.h
@@ -20,6 +20,7 @@ this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include <string>
 #include <memory>
 #include <vector>
 #include <time.h>


### PR DESCRIPTION
Hi,

This PR fixes this error:
```
[ 33%] Building CXX object CMakeFiles/maconv.dir/src/fs/file.cc.o
In file included from /tmp/Maconv/src/fs/file.cc:21:
/tmp/Maconv/src/fs/file.h:49:17: error: field 'filename' has incomplete type 'std::string' {aka 'std::__cxx11::basic_string<char>'}
   49 |     std::string filename; // Name of the file.
      |                 ^~~~~~~~
In file included from /usr/include/c++/10/iosfwd:39,
                 from /usr/include/c++/10/memory:74,
                 from /tmp/Maconv/src/fs/file.h:23,
                 from /tmp/Maconv/src/fs/file.cc:21:
/usr/include/c++/10/bits/stringfwd.h:74:11: note: declaration of 'std::string' {aka 'class std::__cxx11::basic_string<char>'}
   74 |     class basic_string;
      |           ^~~~~~~~~~~~
make[2]: *** [CMakeFiles/maconv.dir/build.make:83: CMakeFiles/maconv.dir/src/fs/file.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:116: CMakeFiles/maconv.dir/all] Error 2
make: *** [Makefile:150: all] Error 2
```