### PR TITLE
Fix compilation errors.

### DIFF
--- a/src/formats/file_signature.cc
+++ b/src/formats/file_signature.cc
@@ -20,6 +20,7 @@ this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "formats/file_signature.h"
 
+#include <array>
 #include <memory>
 
 namespace maconv {

--- a/src/fs/file.h
+++ b/src/fs/file.h
@@ -20,6 +20,7 @@ this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include <string>
 #include <memory>
 #include <vector>
 #include <time.h>

--- a/src/fs/file_writer.h
+++ b/src/fs/file_writer.h
@@ -20,6 +20,7 @@ this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include <cstdint>
 #include <ostream>
 #include <string>
 


### PR DESCRIPTION
- error: field ‘filename’ has incomplete type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
- error: ‘uint8_t’ has not been declared
- error: aggregate ‘std::array<char, 128> buffer’ has incomplete type and cannot be defined