### PR TITLE
Fix compile issues with newer clang compiler (or MacOSX14.2.sdk)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 /build/
+vendors/libhfs/config.h
+*.a
+maconv
+
+Makefile
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(maconv)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 
 # Compile vendor libraries.
 add_subdirectory("vendors/libhfs")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,16 @@
 cmake_minimum_required(VERSION 3.2)
 project(maconv)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+add_compile_options(-Wall)
+add_compile_options(-Wextra)
+
+# Register keyword is gone in C++17 and above.  Okay
+# if we use c++std 14 and just ignore the warning.
+add_compile_options(-Wno-deprecated-register)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Compile vendor libraries.
 add_subdirectory("vendors/libhfs")

--- a/src/conv/binhex.cc
+++ b/src/conv/binhex.cc
@@ -27,7 +27,7 @@ namespace conv {
 
 
 // Return true if a file is in BinHex format.
-bool IsFileBinHex(fs::FileReader &reader)
+bool IsFileBinHex(fs::FileReader &/* reader */)
 {
     // TODO.
 
@@ -37,7 +37,7 @@ bool IsFileBinHex(fs::FileReader &reader)
 
 
 // Read and decode a BinHex file.
-void ReadBinHex(fs::FileReader &reader, fs::File &file)
+void ReadBinHex(fs::FileReader &/* reader */, fs::File &/* file */)
 {
     // TODO.
 }
@@ -45,7 +45,7 @@ void ReadBinHex(fs::FileReader &reader, fs::File &file)
 
 
 // Write a BinHex file.
-void WriteBinHex(fs::File &file, fs::FileWriter &writer)
+void WriteBinHex(fs::File &/* file */, fs::FileWriter &/* writer */)
 {
     // TODO.
 }

--- a/src/disk/extract.cc
+++ b/src/disk/extract.cc
@@ -38,7 +38,7 @@ static void ExtractFork(hfsfile *hfile, const hfsdirent &ent, fs::File &file,
     bool is_res)
 {
     // Allocate buffer.
-    int size = is_res ? ent.u.file.rsize : ent.u.file.dsize;
+    long unsigned int size = is_res ? ent.u.file.rsize : ent.u.file.dsize;
     auto buffer = std::make_unique<uint8_t[]>(size);
 
     // Read the data.

--- a/src/formats/file_signature.cc
+++ b/src/formats/file_signature.cc
@@ -59,10 +59,11 @@ SignToMac signs_to_mac[] = {
 
 
 // File signature array.
+/*
 SignToUnix signs_to_unix[] = {
 
 };
-
+*/
 
 
 // Call Unix "file" command on a path.

--- a/src/formats/file_signature.h
+++ b/src/formats/file_signature.h
@@ -33,13 +33,13 @@ struct SignToMac {
     // Maching type: extension or file command.
     enum Type { Extension, FileCmd } type;
 
-    // Help strings (and count)
-    int help_len;
-    const char **helps;
-
     // MAC creator and type.
     const char *creator;
     const char *mac;
+
+    // Help strings (and count)
+    int help_len;
+    const char **helps;
 
     constexpr SignToMac(Type t, const char *c, const char *m, const char **hs, int hl)
         : type{t}, creator{c}, mac{m}, help_len{hl}, helps{hs} {}

--- a/src/formats/file_signature.h
+++ b/src/formats/file_signature.h
@@ -57,8 +57,9 @@ struct SignToUnix {
 extern SignToMac signs_to_mac[];
 
 // File signature array.
+/*
 extern SignToUnix signs_to_unix[];
-
+*/
 
 
 // Get the MAC type (and creator) for a specific file.

--- a/src/formats/formats.cc
+++ b/src/formats/formats.cc
@@ -34,7 +34,7 @@ namespace maconv {
 
 
 // Prefered conversion format.
-ConvData prefered_conv = { ConvData::NotFound };
+ConvData prefered_conv = { ConvData::NotFound, NULL };
 
 
 // All available converters.
@@ -69,7 +69,7 @@ ConvData GetConverter(const std::string &name)
             return ConvData { ConvData::Double, &format };
     }
 
-    return ConvData { ConvData::NotFound };
+    return ConvData { ConvData::NotFound, NULL };
 }
 
 

--- a/src/fs/file.cc
+++ b/src/fs/file.cc
@@ -71,11 +71,10 @@ int ReadLocalFile(const std::string &filename, fs::DataPtr &ptr)
 
 
 // Get file infotmation from a local file.
-void GetLocalInfo(const std::string &filename, fs::File &file, bool is_res)
+void GetLocalInfo(const std::string & /*filename */, fs::File &/* file */, bool /* is_res */)
 {
     // TODO.
 }
-
 
 
 // Set file infotmation to a local file.

--- a/src/fs/file.h
+++ b/src/fs/file.h
@@ -21,6 +21,7 @@ this program.  If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 #include <memory>
+#include <string>
 #include <vector>
 #include <time.h>
 

--- a/src/fs/file_reader.h
+++ b/src/fs/file_reader.h
@@ -71,10 +71,10 @@ struct FileReader {
 
     uint8_t *data; // Input data.
     uint32_t file_size; // Total size of the file.
+    std::string filename; // Name of the file to read.
 
     utils::RawDataStreamBuf stream_buf; // Stream buffer from raw data buffer.
     std::istream stream; // Stream for reading data.
-    std::string filename; // Name of the file to read.
 };
 
 

--- a/src/stuffit/methods.cc
+++ b/src/stuffit/methods.cc
@@ -68,7 +68,7 @@ void CompressionMethod::Extract(const StuffitCompInfo &info, uint8_t *data,
     total_size = 0;
 
     // Uncompress the data chunk by chunks.
-    for (uint32_t len = 0; true;) {
+    for (int32_t len = 0; true;) {
         len = ReadBytes(buffer.get() + total_size, capacity - total_size);
         if (len == -1)
             break;

--- a/src/stuffit/methods.cc
+++ b/src/stuffit/methods.cc
@@ -89,7 +89,7 @@ void CompressionMethod::Extract(const StuffitCompInfo &info, uint8_t *data,
 
 // Extract data from the compressed fork.
 void NoneMethod::Extract(const StuffitCompInfo &info, uint8_t *data,
-    std::vector<fs::DataPtr> &mem_pool)
+    std::vector<fs::DataPtr> &/* mem_pool */)
 {
     total_size = info.size ? info.size : info.comp_size;
     uncompressed = data + info.offset;

--- a/src/stuffit/methods.h
+++ b/src/stuffit/methods.h
@@ -47,7 +47,7 @@ struct CompressionMethod {
 
 
     // Read the next bytes.
-    virtual int32_t ReadBytes(uint8_t *data, uint32_t length) { return -1; }
+    virtual int32_t ReadBytes(uint8_t * /* data */, uint32_t /* length */) { return -1; }
 
     // Initialize the algorithm.
     virtual void Initialize() {}

--- a/src/utils/buffer_stream.cc
+++ b/src/utils/buffer_stream.cc
@@ -71,7 +71,7 @@ auto RawDataStreamBuf::seekpos(pos_type pos, std::ios_base::openmode which)
     if (which & std::ios_base::in)
         setg(eback(), eback() + pos, egptr());
     if (which & std::ios_base::out)
-        pbump(pos - (pptr() - eback()));
+        pbump(pos - static_cast<pos_type>((pptr() - eback())));
 
     return pos;
 }

--- a/vendors/libhfs/btree.c
+++ b/vendors/libhfs/btree.c
@@ -409,7 +409,7 @@ fail:
  * DESCRIPTION:	recursively locate a node and insert a record
  */
 static
-int insertx(node *np, byte *record, int *reclen)
+int insertx(node *np, byte *record, unsigned int *reclen)
 {
   node child;
   byte *rec;

--- a/vendors/libhfs/volume.c
+++ b/vendors/libhfs/volume.c
@@ -758,7 +758,7 @@ fail:
  * DESCRIPTION:	translate a pathname; return catalog information
  */
 int v_resolve(hfsvol **vol, const char *path,
-              CatDataRec *data, long *parid, char *fname, node *np)
+              CatDataRec *data, unsigned long *parid, char *fname, node *np)
 {
   unsigned long dirid;
   char name[HFS_MAX_FLEN + 1], *nptr;

--- a/vendors/libhfs/volume.h
+++ b/vendors/libhfs/volume.h
@@ -54,7 +54,7 @@ int v_putextrec(const ExtDataRec *, node *);
 int v_allocblocks(hfsvol *, ExtDescriptor *);
 int v_freeblocks(hfsvol *, const ExtDescriptor *);
 
-int v_resolve(hfsvol **, const char *, CatDataRec *, long *, char *, node *);
+int v_resolve(hfsvol **, const char *, CatDataRec *, unsigned long *, char *, node *);
 
 int v_adjvalence(hfsvol *, unsigned long, int, int);
 int v_mkdir(hfsvol *, unsigned long, const char *);


### PR DESCRIPTION
Fails to compile on Sonoma 14.3 related to ambiguous operator overload (-) and pos_type; fix with static_cast;  Add c++ std to CMakeLists.txt (to be c++14) so that c++ std compliant compilers don't get confused.